### PR TITLE
SWIK-610 Sort the slide references read from the [Content_Types].xml

### DIFF
--- a/application/PPTX2HTML/js/convertor.js
+++ b/application/PPTX2HTML/js/convertor.js
@@ -218,6 +218,12 @@ getContentTypes(zip) {
 			default:
 		}
 	}
+
+  //Fix the order of slides
+  slidesLocArray.sort((a, b) => {
+    return parseInt(a.replace(/\D+/g, '')) - parseInt(b.replace(/\D+/g, ''));
+  });
+
 	return {
 		"slides": slidesLocArray,
 		"slideLayouts": slideLayoutsLocArray


### PR DESCRIPTION
This is a small fix which sorts the slide references read from the [Content_Types].xml.
The order of slides is determined by the pptx2html library which reads the [Content_Types].xml (in the root of the pptx file) and makes slides in the order in which they are listed. This order may not be correct when saving from LibreOffice, KeyNote,...