### PR TITLE
Swik 755 svg drawing causes input box editing to behave unituitively

### DIFF
--- a/application/PPTX2HTML/js/convertor.js
+++ b/application/PPTX2HTML/js/convertor.js
@@ -734,6 +734,10 @@ genShape(node, slideLayoutSpNode, slideMasterSpNode, id, name, idx, type, order,
     if (ext === undefined) {
         shapType = '';//prevent it to create a shape
     }
+
+    let svgPos = this.getPosition(slideXfrmNode, undefined, undefined);
+    let svgSize = this.getSize(slideXfrmNode, undefined, undefined);
+
     result += "<div class='drawing-container' _id='" + id + "' _idx='" + idx + "' _type='" + type + "' _name='" + name +
         "' style='position: absolute;"
              + svgPos

--- a/application/PPTX2HTML/js/convertor.js
+++ b/application/PPTX2HTML/js/convertor.js
@@ -734,12 +734,16 @@ genShape(node, slideLayoutSpNode, slideMasterSpNode, id, name, idx, type, order,
     if (ext === undefined) {
         shapType = '';//prevent it to create a shape
     }
-		result += "<svg class='drawing' _id='" + id + "' _idx='" + idx + "' _type='" + type + "' _name='" + name +
-				"' style='position: absolute;" +
-					this.getPosition(slideXfrmNode, undefined, undefined) +
-					this.getSize(slideXfrmNode, undefined, undefined) +
-					" z-index: " + order + ";" +
-				"'>";
+    result += "<div class='drawing-container' _id='" + id + "' _idx='" + idx + "' _type='" + type + "' _name='" + name +
+        "' style='position: absolute;"
+             + svgPos
+             + svgSize
+             + " z-index: " + order + ";'>" +
+        "<svg class='drawing' _id='" + id + "' _idx='" + idx + "' _type='" + type + "' _name='" + name +
+        "' style='position: absolute;"
+             + "top:0px; left:0px;"
+             + svgSize
+             + " z-index: " + order + ";'>";
 
 		// Fill Color
 		var fillColor = this.getFill(node, true);
@@ -1003,7 +1007,7 @@ genShape(node, slideLayoutSpNode, slideMasterSpNode, id, name, idx, type, order,
 				console.warn("Undefine shape type.");
 		}
 
-		result += "</svg>";
+		result += "</svg></div>";
 
 		result += "<div class='block content " + this.getVerticalAlign(node, slideLayoutSpNode, slideMasterSpNode, type) +
 				"' _id='" + id + "' _idx='" + idx + "' _type='" + type + "' _name='" + name +


### PR DESCRIPTION
An SVG image is surrounded by a div container in order to support control buttons.