### PR TITLE
SWIK-836 Corrected NaN value (SVG stroke-width)

### DIFF
--- a/application/PPTX2HTML/js/convertor.js
+++ b/application/PPTX2HTML/js/convertor.js
@@ -1894,7 +1894,10 @@ getBorder(node, isSvgMode) {
 
 	// Border width: 1pt = 12700, default = 0.75pt
 	var borderWidth = parseInt(this.getTextByPathList(lineNode, ["attrs", "w"])) / 12700;
-	if (isNaN(borderWidth) || borderWidth < 1) {
+  if (isNaN(borderWidth)) {
+    borderWidth = 1;
+  }
+	if (borderWidth < 1) {
 		cssText += "1pt ";
 	} else {
 		cssText += borderWidth + "pt ";


### PR DESCRIPTION
This is a small fix which corrects the 'borderWidth' NaN value. 'borderWidth' is used for SvgMode, later in the code.