### PR TITLE
SWIK-1264 bugfix modify pptx for themes

### DIFF
--- a/application/PPTX2HTML/js/convertor.js
+++ b/application/PPTX2HTML/js/convertor.js
@@ -1269,6 +1269,7 @@ genTextBody(textBodyNode, slideLayoutSpNode, slideMasterSpNode, type, warpObj, c
 			}
 
 
+
       const insertListItemTag = (createList && !isSomeKindOfTitle && !isSldNum && (layoutType === undefined) && (pNode["a:pPr"] === undefined || pNode["a:pPr"]["a:buNone"] === undefined));
       const isOrderedList = (pNode["a:pPr"] !== undefined && pNode["a:pPr"]["a:buAutoNum"] !== undefined);
       let itemLevel = "0";
@@ -1295,6 +1296,11 @@ genTextBody(textBodyNode, slideLayoutSpNode, slideMasterSpNode, type, warpObj, c
       text += "<div class='" + this.getHorizontalAlign(pNode, slideLayoutSpNode, slideMasterSpNode, type, slideMasterTextStyles) + "'>";
 
       text += this.genBuChar(pNode);
+
+      console.log("isSomeKindOfTitle ", isSomeKindOfTitle);
+      if(isSomeKindOfTitle){
+        spanElement = '<h3>' + spanElement + '</h3>';
+      }
 
       text += spanElement;
 
@@ -1397,6 +1403,13 @@ genTextBody(textBodyNode, slideLayoutSpNode, slideMasterSpNode, type, warpObj, c
 
     text += this.genBuChar(pNode);
 
+    console.log("isSomeKindOfTitle ", isSomeKindOfTitle);
+    if(isSomeKindOfTitle){
+      spanElement = '<h3>' + spanElement + '</h3>';
+    }
+
+
+
     text += spanElement;
 
     text += "</div>";
@@ -1414,6 +1427,8 @@ genTextBody(textBodyNode, slideLayoutSpNode, slideMasterSpNode, type, warpObj, c
   } else if (isSubTitle && this.currentSlide.subTitle === '') {
     this.currentSlide.subTitle = title;
   }
+
+  console.log(text);
 
 	return text;
 }
@@ -1575,14 +1590,29 @@ __proto__: Array[0]
     //console.log('///////////////////////////////////////////////////linkID');
     //console.log(linkID);
     //console.log('///////////////////////////////////////////////////linkID');
+    //HF: If it's a title, then we want heading tags rather than a span tag.
+    // This means we don't have to rely on titleBodySize
+
+    const isTitle = (type === 'title');
+    const isSubTitle = (type === 'subTitle');
+    const isCtrTitle = (type === 'ctrTitle');
+    const isSomeKindOfTitle = (isTitle || isSubTitle || isCtrTitle);
+
+    let elementName = "span";
+    if(isSomeKindOfTitle){
+      elementName = "span";
+    }
+    let element = "<" + elementName +  "class='text-block' " + textStyle + ">";
 
     if (linkID !== undefined && warpObj["slideResObj"] !== undefined) {
       let linkURL = warpObj["slideResObj"][linkID]["target"];
-      return "<span class='text-block' " + textStyle + "><a href='" + linkURL + "' target='_blank'>" + text.replace(/\s/i, "&nbsp;") + "</a></span>";
+      return element + "<a href='" + linkURL + "' target='_blank'>" + text.replace(/\s/i, "&nbsp;") + "</a></" + elementName + ">";
   	} else {
-  		return "<span class='text-block' " + textStyle + ">" + text.replace(/\s/i, "&nbsp;") + "</span>";
+  		return element + text.replace(/\s/i, "&nbsp;") + "</" + elementName + ">";
     }
 }
+
+
 
 genTable(node, warpObj) {
 

--- a/application/PPTX2HTML/js/convertor.js
+++ b/application/PPTX2HTML/js/convertor.js
@@ -1590,25 +1590,13 @@ __proto__: Array[0]
     //console.log('///////////////////////////////////////////////////linkID');
     //console.log(linkID);
     //console.log('///////////////////////////////////////////////////linkID');
-    //HF: If it's a title, then we want heading tags rather than a span tag.
-    // This means we don't have to rely on titleBodySize
 
-    const isTitle = (type === 'title');
-    const isSubTitle = (type === 'subTitle');
-    const isCtrTitle = (type === 'ctrTitle');
-    const isSomeKindOfTitle = (isTitle || isSubTitle || isCtrTitle);
-
-    let elementName = "span";
-    if(isSomeKindOfTitle){
-      elementName = "span";
-    }
-    let element = "<" + elementName +  "class='text-block' " + textStyle + ">";
 
     if (linkID !== undefined && warpObj["slideResObj"] !== undefined) {
       let linkURL = warpObj["slideResObj"][linkID]["target"];
-      return element + "<a href='" + linkURL + "' target='_blank'>" + text.replace(/\s/i, "&nbsp;") + "</a></" + elementName + ">";
+      return "<span class='text-block' " + textStyle + "><a href='" + linkURL + "' target='_blank'>" + text.replace(/\s/i, "&nbsp;") + "</a></span>";
   	} else {
-  		return element + text.replace(/\s/i, "&nbsp;") + "</" + elementName + ">";
+  		return "<span class='text-block' " + textStyle + ">" + text.replace(/\s/i, "&nbsp;") + "</span>";
     }
 }
 

--- a/application/PPTX2HTML/js/convertor.js
+++ b/application/PPTX2HTML/js/convertor.js
@@ -1851,24 +1851,24 @@ getVerticalAlign(node, slideLayoutSpNode, slideMasterSpNode, type, slideMasterTe
 
 getFontType(node, type, slideMasterTextStyles) {
 	var typeface = this.getTextByPathList(node, ["a:rPr", "a:latin", "attrs", "typeface"]);
-
-	if (typeface === undefined) {
-		var fontSchemeNode = this.getTextByPathList(this.themeContent, ["a:theme", "a:themeElements", "a:fontScheme"]);
-		if (type == "title" || type == "subTitle" || type == "ctrTitle") {
-			typeface = this.getTextByPathList(fontSchemeNode, ["a:majorFont", "a:latin", "attrs", "typeface"]);
-		} else if (type == "body") {
-			typeface = this.getTextByPathList(fontSchemeNode, ["a:minorFont", "a:latin", "attrs", "typeface"]);
-		} else {
-			typeface = this.getTextByPathList(fontSchemeNode, ["a:minorFont", "a:latin", "attrs", "typeface"]);
-		}
-	}
-
+    // SWIK-1123 HF: I'm butchering the function to avoid inline CSS so we can use themes.
+	// if (typeface === undefined) {
+	// 	var fontSchemeNode = this.getTextByPathList(this.themeContent, ["a:theme", "a:themeElements", "a:fontScheme"]);
+	// 	if (type == "title" || type == "subTitle" || type == "ctrTitle") {
+	// 		typeface = this.getTextByPathList(fontSchemeNode, ["a:majorFont", "a:latin", "attrs", "typeface"]);
+	// 	} else if (type == "body") {
+	// 		typeface = this.getTextByPathList(fontSchemeNode, ["a:minorFont", "a:latin", "attrs", "typeface"]);
+	// 	} else {
+	// 		typeface = this.getTextByPathList(fontSchemeNode, ["a:minorFont", "a:latin", "attrs", "typeface"]);
+	// 	}
+	// }
+    //
 	return (typeface === undefined) ? "inherit" : typeface;
 }
 
 getFontColor(node, type, slideMasterTextStyles) {
 	var color = this.getTextByPathStr(node, "a:rPr a:solidFill a:srgbClr attrs val");
-	return (color === undefined) ? "#000" : "#" + color;
+	return (color === undefined) ? "inherit" : "#" + color;
 }
 
 getFontSize(node, slideLayoutSpNode, slideMasterSpNode, type, slideMasterTextStyles) {
@@ -1876,39 +1876,41 @@ getFontSize(node, slideLayoutSpNode, slideMasterSpNode, type, slideMasterTextSty
 	if (node["a:rPr"] !== undefined) {
 		fontSize = parseInt(node["a:rPr"]["attrs"]["sz"]) / 100;
 	}
-
-	if ((isNaN(fontSize) || fontSize === undefined)) {
-		var sz = this.getTextByPathList(slideLayoutSpNode, ["p:txBody", "a:lstStyle", "a:lvl1pPr", "a:defRPr", "attrs", "sz"]);
-		fontSize = parseInt(sz) / 100;
-	}
-
-	if (isNaN(fontSize) || fontSize === undefined) {
-		if (type == "title" || type == "subTitle" || type == "ctrTitle") {
-			var sz = this.getTextByPathList(slideMasterTextStyles, ["p:titleStyle", "a:lvl1pPr", "a:defRPr", "attrs", "sz"]);
-		} else if (type == "body") {
-			var sz = this.getTextByPathList(slideMasterTextStyles, ["p:bodyStyle", "a:lvl1pPr", "a:defRPr", "attrs", "sz"]);
-		} else if (type == "dt" || type == "sldNum") {
-			var sz = "1200";
-		} else if (type === undefined) {
-			var sz = this.getTextByPathList(slideMasterTextStyles, ["p:otherStyle", "a:lvl1pPr", "a:defRPr", "attrs", "sz"]);
-		}
-		fontSize = parseInt(sz) / 100;
-	}
-
-	var baseline = this.getTextByPathList(node, ["a:rPr", "attrs", "baseline"]);
-	if (baseline !== undefined && !isNaN(fontSize)) {
-		fontSize -= 10;
-	}
+    // SWIK-1123  HF: I'm butchering the function to avoid inline CSS so we can use themes.
+	// if ((isNaN(fontSize) || fontSize === undefined)) {
+	// 	var sz = this.getTextByPathList(slideLayoutSpNode, ["p:txBody", "a:lstStyle", "a:lvl1pPr", "a:defRPr", "attrs", "sz"]);
+	// 	fontSize = parseInt(sz) / 100;
+	// }
+    //
+	// if (isNaN(fontSize) || fontSize === undefined) {
+	// 	if (type == "title" || type == "subTitle" || type == "ctrTitle") {
+	// 		var sz = this.getTextByPathList(slideMasterTextStyles, ["p:titleStyle", "a:lvl1pPr", "a:defRPr", "attrs", "sz"]);
+	// 	} else if (type == "body") {
+	// 		var sz = this.getTextByPathList(slideMasterTextStyles, ["p:bodyStyle", "a:lvl1pPr", "a:defRPr", "attrs", "sz"]);
+	// 	} else if (type == "dt" || type == "sldNum") {
+	// 		var sz = "1200";
+	// 	} else if (type === undefined) {
+	// 		var sz = this.getTextByPathList(slideMasterTextStyles, ["p:otherStyle", "a:lvl1pPr", "a:defRPr", "attrs", "sz"]);
+	// 	}
+	// 	fontSize = parseInt(sz) / 100;
+	// }
+    //
+	// var baseline = this.getTextByPathList(node, ["a:rPr", "attrs", "baseline"]);
+	// if (baseline !== undefined && !isNaN(fontSize)) {
+	// 	fontSize -= 10;
+	// }
 
 	return isNaN(fontSize) ? "inherit" : (fontSize + "pt");
 }
 
 getFontBold(node, type, slideMasterTextStyles) {
-	return (node["a:rPr"] !== undefined && node["a:rPr"]["attrs"]["b"] === "1") ? "bold" : "initial";
+    //SWIK-1123 HF: Changing to inherit from initial
+	return (node["a:rPr"] !== undefined && node["a:rPr"]["attrs"]["b"] === "1") ? "bold" : "inherit";
 }
 
 getFontItalic(node, type, slideMasterTextStyles) {
-	return (node["a:rPr"] !== undefined && node["a:rPr"]["attrs"]["i"] === "1") ? "italic" : "normal";
+    //SWIK-1123 HF: Changing to inherit from normal
+	return (node["a:rPr"] !== undefined && node["a:rPr"]["attrs"]["i"] === "1") ? "italic" : "inherit";
 }
 
 getFontDecoration(node, type, slideMasterTextStyles) {

--- a/application/PPTX2HTML/js/convertor.js
+++ b/application/PPTX2HTML/js/convertor.js
@@ -1297,9 +1297,9 @@ genTextBody(textBodyNode, slideLayoutSpNode, slideMasterSpNode, type, warpObj, c
 
       text += this.genBuChar(pNode);
 
-      console.log("isSomeKindOfTitle ", isSomeKindOfTitle);
+      // HF For the titles, we need to give them heading tags
       if(isSomeKindOfTitle){
-        spanElement = '<h3>' + spanElement + '</h3>';
+        spanElement = applyTitle(spanElement, type)
       }
 
       text += spanElement;
@@ -1403,12 +1403,10 @@ genTextBody(textBodyNode, slideLayoutSpNode, slideMasterSpNode, type, warpObj, c
 
     text += this.genBuChar(pNode);
 
-    console.log("isSomeKindOfTitle ", isSomeKindOfTitle);
+    // HF For the titles, we need to give them heading tags
     if(isSomeKindOfTitle){
-      spanElement = '<h3>' + spanElement + '</h3>';
+      spanElement = applyTitle(spanElement, type)
     }
-
-
 
     text += spanElement;
 
@@ -1428,10 +1426,20 @@ genTextBody(textBodyNode, slideLayoutSpNode, slideMasterSpNode, type, warpObj, c
     this.currentSlide.subTitle = title;
   }
 
-  console.log(text);
-
 	return text;
 }
+
+//HF: Rather than writing this twice, I created a function.
+// Should only be called if it is a title of some kind
+  applyTitle(spanElement, type){
+    if(type === 'subTitle'){
+      spanElement = '<h4>' + spanElement + '</h4>';
+    }
+    else{
+      spanElement = '<h3>' + spanElement + '</h3>';
+    }
+    return spanElement;
+  }
 
 getText(node) {//Get raw text from a:r (a:p) node - for the slide title
   let text = node["a:t"];

--- a/application/PPTX2HTML/js/convertor.js
+++ b/application/PPTX2HTML/js/convertor.js
@@ -1303,7 +1303,7 @@ genTextBody(textBodyNode, slideLayoutSpNode, slideMasterSpNode, type, warpObj, c
 
       // HF For the titles, we need to give them heading tags
       if(isSomeKindOfTitle){
-        spanElement = applyTitle(spanElement, type)
+        spanElement = this.applyTitle(spanElement, type);
       }
 
       text += spanElement;
@@ -1409,7 +1409,7 @@ genTextBody(textBodyNode, slideLayoutSpNode, slideMasterSpNode, type, warpObj, c
 
     // HF For the titles, we need to give them heading tags
     if(isSomeKindOfTitle){
-      spanElement = applyTitle(spanElement, type)
+      spanElement = this.applyTitle(spanElement, type);
     }
 
     text += spanElement;

--- a/application/configs/microservices.js
+++ b/application/configs/microservices.js
@@ -4,14 +4,14 @@ const co = require('../common');
 
 module.exports = {
   'deck': {
-    uri: (!co.isEmpty(process.env.SERVICE_URL_DECK)) ? process.env.SERVICE_URL_DECK : 'http://deckservice'
+    uri: (!co.isEmpty(process.env.SERVICE_URL_DECK)) ? process.env.SERVICE_URL_DECK : 'http://deckservice.experimental.slidewiki.org'
   },
   'file': {
-    uri: (!co.isEmpty(process.env.SERVICE_URL_FILE)) ? process.env.SERVICE_URL_FILE : 'http://fileservice',
+    uri: (!co.isEmpty(process.env.SERVICE_URL_FILE)) ? process.env.SERVICE_URL_FILE : 'http://fileservice.experimental.slidewiki.org',
     shareVolume: '/data/files'
   }  ,
   'unoconv': {
-    uri: (!co.isEmpty(process.env.SERVICE_URL_UNOCONV)) ? process.env.SERVICE_URL_UNOCONV : 'http://unoconvservice',
+    uri: (!co.isEmpty(process.env.SERVICE_URL_UNOCONV)) ? process.env.SERVICE_URL_UNOCONV : 'http://unoconvservice.experimental.slidewiki.org',
     protocol: 'https:',
     host: (!co.isEmpty(process.env.SERVICE_HOST_UNOCONV)) ? process.env.SERVICE_HOST_UNOCONV : 'unoconvservice',
     path: '/unoconv/pptx',

--- a/application/controllers/handler.js
+++ b/application/controllers/handler.js
@@ -17,8 +17,9 @@ let Convertor = require('../PPTX2HTML/js/convertor.js');
 //require('../PPTX2HTML/js/pptx2html');
 
 //import pptx2html from '../PPTX2HTML/js/pptx2html';
-
+console.log("Hello?");
 module.exports = {
+
   //Import uploaded PPTX and transform to HTML via PPTX2HTML  or return ERROR
   //TODO: can I run client-side non ES6 javascript in node.js?
   //pptx2html/js/pptx2html.js uses document.ready / Jquery
@@ -31,7 +32,7 @@ module.exports = {
     //reply(request.payload.file);
     //request.log('ImportPPTX', 'ImportPPTX service called' + request.payload.file);
     //console.log('ImportPPTX data' + request.payload.file);
-
+    console.log("module.exports");
 //see https://github.com/risis-eu/risis-datasets/blob/master/plugins/upload/handleUpload.js#L99
 // for example of reading a superagent request
     //!!!request.body!!!

--- a/application/controllers/handler.js
+++ b/application/controllers/handler.js
@@ -17,7 +17,7 @@ let Convertor = require('../PPTX2HTML/js/convertor.js');
 //require('../PPTX2HTML/js/pptx2html');
 
 //import pptx2html from '../PPTX2HTML/js/pptx2html';
-console.log("Hello?");
+// console.log("Hello?");
 module.exports = {
 
   //Import uploaded PPTX and transform to HTML via PPTX2HTML  or return ERROR
@@ -32,7 +32,7 @@ module.exports = {
     //reply(request.payload.file);
     //request.log('ImportPPTX', 'ImportPPTX service called' + request.payload.file);
     //console.log('ImportPPTX data' + request.payload.file);
-    console.log("module.exports");
+    // console.log("module.exports");
 //see https://github.com/risis-eu/risis-datasets/blob/master/plugins/upload/handleUpload.js#L99
 // for example of reading a superagent request
     //!!!request.body!!!

--- a/application/package.json
+++ b/application/package.json
@@ -20,6 +20,7 @@
     "coverall": "npm run coverage && cat ./coverage/lcov.info | coveralls && rm -rf ./coverage",
     "countLOC": "sloc -f cli-table -k total,source,comment,empty -e node_modules\\|coverage ./",
     "countLOC:details": "sloc -f cli-table -d -e node_modules\\|coverage ./",
+    "dev": "node --debug=5858 server.js",
     "start:watch": "nodemon",
     "start:mongodb": "docker run -d --name mongotest -p 27018:27017 mongo",
     "stop:mongodb": "docker stop mongotest && docker rm mongotest"

--- a/application/server.js
+++ b/application/server.js
@@ -12,7 +12,7 @@ const hapi = require('hapi'),
 //Initiate the webserver with standard or given port
 const server = new hapi.Server({ connections: {routes: {validate: { options: {convert : false}}}}});
 
-let port = (!co.isEmpty(process.env.APPLICATION_PORT)) ? process.env.APPLICATION_PORT : 3000;
+let port = (!co.isEmpty(process.env.APPLICATION_PORT)) ? process.env.APPLICATION_PORT : 4000;
 server.connection({
   port: port
 });


### PR DESCRIPTION
I did this as part of SWIK-1264, which was required as a result of limitations from SWIK-1123.  I have modified the inline styles generated by cutting down the functions which generated the inline styles, to not make any inferences unless a change was specified. I had to include <h3> and <h4> tags around headings and subheadings respectively, because that relied on assumptions about the text size in the class.

