### PR TITLE
Revert microservices.js config change

### DIFF
--- a/application/configs/microservices.js
+++ b/application/configs/microservices.js
@@ -4,14 +4,14 @@ const co = require('../common');
 
 module.exports = {
   'deck': {
-    uri: (!co.isEmpty(process.env.SERVICE_URL_DECK)) ? process.env.SERVICE_URL_DECK : 'https://deckservice.experimental.slidewiki.org'
+    uri: (!co.isEmpty(process.env.SERVICE_URL_DECK)) ? process.env.SERVICE_URL_DECK : 'http://deckservice'
   },
   'file': {
-    uri: (!co.isEmpty(process.env.SERVICE_URL_FILE)) ? process.env.SERVICE_URL_FILE : 'https://fileservice.experimental.slidewiki.org',
+    uri: (!co.isEmpty(process.env.SERVICE_URL_FILE)) ? process.env.SERVICE_URL_FILE : 'http://fileservice',
     shareVolume: '/data/files'
   }  ,
   'unoconv': {
-    uri: (!co.isEmpty(process.env.SERVICE_URL_UNOCONV)) ? process.env.SERVICE_URL_UNOCONV : 'https://unoconvservice.experimental.slidewiki.org',
+    uri: (!co.isEmpty(process.env.SERVICE_URL_UNOCONV)) ? process.env.SERVICE_URL_UNOCONV : 'http://unoconvservice',
     protocol: 'https:',
     host: (!co.isEmpty(process.env.SERVICE_HOST_UNOCONV)) ? process.env.SERVICE_HOST_UNOCONV : 'unoconvservice',
     path: '/unoconv/pptx',


### PR DESCRIPTION
I accidentally added the dev version of microservice.js in my previous PR.  This is removing the URLs to experimental